### PR TITLE
de-DE: Fixed "groupPanelEmpty" text

### DIFF
--- a/messages/de-DE/de-DE.json
+++ b/messages/de-DE/de-DE.json
@@ -1,6 +1,6 @@
 {
     "grid":{
-        "groupPanelEmpty": "Ziehen Sie einen Spaltentitel hierher um nach dieser Spalte zu gruppieren",
+        "groupPanelEmpty": "Ziehen Sie einen Spaltentitel hierher, um nach dieser Spalte zu gruppieren",
         "pagerItemsPerPage": "Einträge pro Seite",
         "pagerInfo": "{0} - {1} von {2} Einträgen",
         "pagerFirstPage": "Zur ersten Seite",


### PR DESCRIPTION
Added missing comma for the "groupPanelEmpty" text of the grid. The missing comma was an grammatical error.