### PR TITLE
Resolve a formatting issue in the German translations

### DIFF
--- a/messages/de-DE/de-DE.json
+++ b/messages/de-DE/de-DE.json
@@ -32,7 +32,7 @@
         "filterAfterOperator": "Danach",
         "filterBeforeOperator":"Davor",
         "filterBeforeOrEqualOperator":"Davor oder gleich",
-        "noRecords":"Keine Einträge vorhanden."
+        "noRecords":"Keine Einträge vorhanden.",
         "filterAriaLabel": "Filter",
     	"filterCheckAll": "Alle prüfen",
     	"filterChooseOperator": "Operator wählen",


### PR DESCRIPTION
Commit 73ecc53d3007e9e4305be7bb284e44524b7db975 added some new German translations, but it introduced a formatting issue. 

I have already signed the CLA. 